### PR TITLE
Fix space eating issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function extract(code) {
         return;
       }
 
+      scriptCode[scriptCode.length - 1] = scriptCode[scriptCode.length - 1].replace(/[ \t]*$/, "");
       inScript = false;
       index = parser.startIndex;
       indent = null;
@@ -58,8 +59,6 @@ function extract(code) {
         lineNumber += 1;
         return line;
       });
-
-      data = data.replace(/[ \t]*$/, "");
 
       lineNumber -= 1;
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "eslint-plugin-html",
+  "version": "0.0.1",
   "dependencies": {
     "htmlparser2": "^3.8.2"
   }


### PR DESCRIPTION
The issue is if there's a less than symbol in the script it comes
through the `ontext` callback separated before and after. So for
example

     if (a < b) { doit(); }

gets split into `if (a ` (space after `a`) and `< b) { doit(); }`
A line in the `ontext` handler scripts trailing whitespec so when
finally reassembled it comes out with

     if (a< b) { doit(); }

Which no longer lints correctly with certain rules on.

I think the solution is to strip the only the last string in each
script tag