### PR TITLE
Stop non-JS lines breaking no-multiple-empty-lines

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -29,7 +29,9 @@ function extract(code) {
       inScript = true;
       var newLines = code.slice(index, parser.endIndex).match(/\n\r|\n|\r/g);
       if (newLines) {
-        scriptCode.push.apply(scriptCode, newLines);
+        scriptCode.push.apply(scriptCode, newLines.map(function (newLine) {
+          return "//eslint-disable-line spaced-comment" + newLine
+        }));
         lineNumber += newLines.length;
       }
     },


### PR DESCRIPTION
Prior, the series of empty lines in the document that represent non-JavaScript code would break the no-multiple-empty-lines rule. Instead of making empty lines, this patch fills those lines with comments, that in turn have the spaced-comment rule disabled to avoid causing errors if the filler comment doesn't match with the code's style.