### PR TITLE
Allow the <script type="text/ecmascript-6"> tag to be parsed

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -28,7 +28,7 @@ function iterateScripts(code, onScript) {
         return;
       }
 
-      if (attrs.type && !/^(application|text)\/(x-)?(javascript|babel)$/i.test(attrs.type)) {
+      if (attrs.type && !/^(application|text)\/(x-)?(javascript|babel|ecmascript-6)$/i.test(attrs.type)) {
         return;
       }
 


### PR DESCRIPTION
Some IDE need this tag to allow es6 inside inline scripts, one good example is using Polymer and web components with webstorm (intelliJ)

Currently `<script type="text/ecmascript-6">` are ignored