### PR TITLE
Add gray matter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "main": "src/index.js",
   "dependencies": {
+    "gray-matter": "^2.0.2",
     "htmlparser2": "^3.8.2"
   },
   "devDependencies": {

--- a/src/extract.js
+++ b/src/extract.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var htmlparser = require("htmlparser2");
+var grayMatter = require("gray-matter");
 
 function parseIndentDescriptor(indentDescriptor) {
   var match = /^(\+)?(tab|\d+)$/.exec(indentDescriptor);
@@ -65,7 +66,16 @@ function extract(code, rawIndentDescriptor, reportBadIndentation) {
   var indentDescriptor = parseIndentDescriptor(rawIndentDescriptor);
   var resultCode = "";
   var map = [];
+  var parsed = grayMatter(code);
+  var matter = code.substring(0, code.indexOf(parsed.content));
+  code = parsed.content;
+  var matterLines = matter.match(/\r\n|\n|\r/g);
   var lineNumber = 1;
+  if (matterLines && matterLines.length) {
+    resultCode += matterLines.map(function (newLine) {
+      return "//eslint-disable-line spaced-comment" + newLine
+    }).join("");
+  }
   var badIndentationLines = [];
 
   iterateScripts(code, function (previousCode, scriptCode) {

--- a/test/fixtures/frontmatter.html
+++ b/test/fixtures/frontmatter.html
@@ -1,0 +1,17 @@
+---
+name: Page
+layout: default
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Test</title>
+    <script>
+      console.log(1);
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -51,6 +51,16 @@ describe("plugin", function () {
     assert.equal(messages[4].column, 13);
   });
 
+  it("ignores front matter", function () {
+    var messages = execute("frontmatter.html");
+
+    assert.equal(messages.length, 1);
+
+    assert.equal(messages[0].message, "Unexpected console statement.");
+    assert.equal(messages[0].line, 12);
+    assert.equal(messages[0].column, 1);
+  });
+
   it("should report correct line numbers with crlf newlines", function () {
     var messages = execute("crlf-newlines.html");
 


### PR DESCRIPTION
This automatically strips YAML headers like those used in Jekyll
from HTML input. It doesn't affect existing HTML input, and correctly
adjusts line numbers so they match the page + header.

Fixes #18