### PR TITLE
fix problem with Atom

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function createProcessor(defaultXMLMode) {
   var verify = eslint.verify;
   var reportBadIndent;
 
-  var currentInfos;
+  var currentInfos = {};
 
   function patch() {
     eslint.verify = function (textOrSourceCode, config, filenameOrOptions, saveState) {


### PR DESCRIPTION
This fixed a crash which occurs when eslint is run via linter-eslint Atom plugin