### PR TITLE
Add .tag extension for riot tags.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ var htmlExtensions = [
   ".html",
   ".mustache",
   ".php",
+  ".tag",
   ".twig",
   ".vue",
 ];


### PR DESCRIPTION
RiotJS uses `.tag` files for its custom tags: http://riotjs.com/#custom-tags

Though seeing how fast the `htmlExtensions` array is growing, maybe it would be a better idea to make it configurable through `.eslintrc`?