### PR TITLE
Add .erb to HTML extensions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ var htmlExtensions = [
   ".tag",
   ".twig",
   ".vue",
+  ".erb",
 ];
 
 var xmlExtensions = [


### PR DESCRIPTION
Although .erb can be used in any situation, mostly it means "HTML with embedded Ruby".