### PR TITLE
Avoid all lint errors on non-script linefeeds via eslint-disable-line

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -87,7 +87,7 @@ function extract(code, options) {
     var newLines = previousCode.match(/\r\n|\n|\r/g);
     if (newLines) {
       resultCode += newLines.map(function (newLine) {
-        return "//eslint-disable-line spaced-comment" + newLine
+        return "//eslint-disable-line" + newLine
       }).join("");
       lineNumber += newLines.length;
       map[lineNumber] = previousCode.match(/[^\n\r]*$/)[0].length;

--- a/test/extract.js
+++ b/test/extract.js
@@ -5,7 +5,7 @@
 var assert = require("assert");
 var extract = require("../src/extract");
 
-var htmlLine = "//eslint-disable-line spaced-comment";
+var htmlLine = "//eslint-disable-line";
 
 function dedent(str) {
   if (str[0] === "\n") str = str.slice(1);

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -266,4 +266,16 @@ describe("plugin", function () {
     });
   });
 
+  describe("lines-around-comment and multiple scripts", () => {
+    it("should not warn with lines-around-comment if multiple scripts", () => {
+      var messages = execute("simple.html", {
+        "rules": {
+          "lines-around-comment": ["error", { "beforeLineComment": true }]
+        }
+      });
+
+      assert.equal(messages.length, 5);
+    });
+  });
+
 });


### PR DESCRIPTION
While trying to consume this plugin in the [QUnit repository](https://github.com/qunitjs/qunit), I discovered a bug with the `//eslint-disable-line` comments emitted by the extractor. Basically, they can also be subjected to the "lines-around-comment" rule in addition to "comment-spacing". Since the goal of those lines is merely to preserve location info between script tags and no actual code is contained within, I decided to generalize the comment so that all rules were disabled.

I've also added a test case which fails without the source change. Please let me know if you need anything else.