### PR TITLE
Added bublé to suported scripts type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Supported XHTML extensions:
 * .xml
 
 Only script tags with no type attribute or a type attribute containing a MIME type known to
-represent JavaScript such as `text/javascript` or `application/javascript`, or `text/babel` will be
+represent JavaScript such as `text/javascript` or `application/javascript`, or `text/babel` or `text/buble` will be
 linted.
 
 

--- a/src/__tests__/extract.js
+++ b/src/__tests__/extract.js
@@ -180,7 +180,7 @@ const prefixes = ["text/",
                 "application/",
                 "application/x-"]
 
-const types = ["javascript", "babel"]
+const types = ["javascript", "babel", "buble"]
 
 for (const prefix of prefixes) {
   for (const type of types) {

--- a/src/extract.js
+++ b/src/extract.js
@@ -29,7 +29,7 @@ function iterateScripts(code, options, onScript) {
         return
       }
 
-      if (attrs.type && !/^(application|text)\/(x-)?(javascript|babel|ecmascript-6)$/i.test(attrs.type)) {
+      if (attrs.type && !/^(application|text)\/(x-)?(javascript|babel|ecmascript-6|buble)$/i.test(attrs.type)) {
         return
       }
 


### PR DESCRIPTION
[Bublé](https://gitlab.com/Rich-Harris/buble) is ES2015 compiler, like a babel.

This PR allow `<script type="text/buble">` to be parse.