### PR TITLE
Lint HTML attributes by creating a virtual <script> element

### DIFF
--- a/src/__tests__/fixtures/attributes.html
+++ b/src/__tests__/fixtures/attributes.html
@@ -1,0 +1,9 @@
+<form id="the-form" onsubmit="return checkSubmit(1)" onFoo4="var a">
+  <p>Test</p>
+</form>
+
+<script>
+  function checkSubmit(num) {
+    return num
+  }
+</script>

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -702,3 +702,33 @@ describe("scope sharing", () => {
     expect(messages[15].message).toBe("'ClassGloballyDeclared' is not defined.")
   })
 })
+
+describe("linting attributes", () => {
+  it("should respect no-unused-vars rule", () => {
+    const messages = execute("attributes.html", {
+      rules: {
+        "no-unused-vars": "error"
+      },
+    })
+    expect(messages.length).toBe(0);
+  })
+  it("should respect semi rule", () => {
+    const messages = execute("attributes.html", {
+      rules: {
+        "semi": ["error", "never"]
+      },
+    })
+    expect(messages.length).toBe(0);
+  })
+  it("should respect indent rule", () => {
+    const messages = execute("attributes.html", {
+      rules: {
+        "indent": ["error", "tab"]
+      },
+    })
+    expect(messages.length).toBe(1);
+    expect(messages[0].message).toBe("Expected indentation of 1 tab but found 2 spaces.");
+    messages.forEach(function(message) {
+    });
+  })
+})

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -707,7 +707,7 @@ describe("linting attributes", () => {
   it("should respect no-unused-vars rule", () => {
     const messages = execute("attributes.html", {
       rules: {
-        "no-unused-vars": "error"
+        "no-unused-vars": "error",
       },
     })
     expect(messages.length).toBe(0);
@@ -715,7 +715,7 @@ describe("linting attributes", () => {
   it("should respect semi rule", () => {
     const messages = execute("attributes.html", {
       rules: {
-        "semi": ["error", "never"]
+        "semi": ["error", "never"],
       },
     })
     expect(messages.length).toBe(0);
@@ -723,12 +723,10 @@ describe("linting attributes", () => {
   it("should respect indent rule", () => {
     const messages = execute("attributes.html", {
       rules: {
-        "indent": ["error", "tab"]
+        "indent": ["error", "tab"],
       },
     })
-    expect(messages.length).toBe(1);
-    expect(messages[0].message).toBe("Expected indentation of 1 tab but found 2 spaces.");
-    messages.forEach(function(message) {
-    });
+    expect(messages.length).toBe(1)
+    expect(messages[0].message).toBe("Expected indentation of 1 tab but found 2 spaces.")
   })
 })

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -727,6 +727,8 @@ describe("linting attributes", () => {
       },
     })
     expect(messages.length).toBe(1)
-    expect(messages[0].message).toBe("Expected indentation of 1 tab but found 2 spaces.")
+    expect(messages[0].message).toBe(`
+      "Expected indentation of 1 tab but found 2 spaces."
+    `)
   })
 })

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -710,20 +710,20 @@ describe("linting attributes", () => {
         "no-unused-vars": "error",
       },
     })
-    expect(messages.length).toBe(0);
+    expect(messages.length).toBe(0)
   })
   it("should respect semi rule", () => {
     const messages = execute("attributes.html", {
       rules: {
-        "semi": ["error", "never"],
+        semi: ["error", "never"],
       },
     })
-    expect(messages.length).toBe(0);
+    expect(messages.length).toBe(0)
   })
   it("should respect indent rule", () => {
     const messages = execute("attributes.html", {
       rules: {
-        "indent": ["error", "tab"],
+        indent: ["error", "tab"],
       },
     })
     expect(messages.length).toBe(1)

--- a/src/__tests__/plugin.js
+++ b/src/__tests__/plugin.js
@@ -727,8 +727,8 @@ describe("linting attributes", () => {
       },
     })
     expect(messages.length).toBe(1)
-    expect(messages[0].message).toBe(`
+    expect(messages[0].message).toBe(
       "Expected indentation of 1 tab but found 2 spaces."
-    `)
+    )
   })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -86,15 +86,22 @@ function addOnXXX(textOrSourceCode, config) {
     onopentag(name, attrs) {
       for (const id in attrs) {
         if (regex.test(id)) {
-          virtualScriptContent = virtualScriptContent.concat(`${indent}${indent}${attrs[id]}\n`)
+          virtualScriptContent = virtualScriptContent.concat(
+            `${indent}${indent}${attrs[id]}\n`
+          )
         }
       }
-    }
+    },
   })
   parser.parseComplete(textOrSourceCode)
   if (virtualScriptContent.length) {
     let semi = ";"
-    if (config && config.rules && config.rules.semi && config.rules.semi.includes("never")) {
+    if (
+      config &&
+      config.rules &&
+      config.rules.semi &&
+      config.rules.semi.includes("never")
+    ) {
       semi = ""
     }
     virtualScriptContent = virtualScriptContent.slice(0, -1)

--- a/src/index.js
+++ b/src/index.js
@@ -73,10 +73,20 @@ function iterateESLintModules(fn) {
   }
 }
 
+function includes(array, element) {
+  let r = false
+  array.forEach(e => {
+    if (e === element) {
+      r = true
+    }
+  })
+  return r
+}
+
 function addOnXXX(textOrSourceCode, config) {
   let indent = "    "
   if (config && config.rules && config.rules.indent) {
-    if (config.rules.indent.includes("tab")) {
+    if (includes(config.rules.indent, "tab")) {
       indent = "\t"
     }
   }
@@ -100,7 +110,7 @@ function addOnXXX(textOrSourceCode, config) {
       config &&
       config.rules &&
       config.rules.semi &&
-      config.rules.semi.includes("never")
+      includes(config.rules.semi, "never")
     ) {
       semi = ""
     }

--- a/src/index.js
+++ b/src/index.js
@@ -74,14 +74,14 @@ function iterateESLintModules(fn) {
 }
 
 function addOnXXX(textOrSourceCode, config) {
-  var indent = "    "
+  let indent = "    "
   if(config && config.rules && config.rules.indent) {
     if(config.rules.indent.includes("tab")) {
       indent = "\t"
     }
   }
-  var virtualScriptContent = ""
-  var regex = /^on[a-zA-Z]+$/
+  let virtualScriptContent = ""
+  const regex = /^on[a-zA-Z]+$/
   const parser = new htmlparser.Parser(
     {
       onopentag(name, attrs) {
@@ -95,12 +95,12 @@ function addOnXXX(textOrSourceCode, config) {
   )
   parser.parseComplete(textOrSourceCode)
   if(virtualScriptContent.length) {
-    var semi = ";"
+    let semi = ";"
     if(config && config.rules && config.rules.semi && config.rules.semi.includes("never")) {
       semi = ""
     }
     virtualScriptContent = virtualScriptContent.slice(0, -1)
-    var virtualScript = `<script>
+    const virtualScript = `<script>
 ${indent}function virtualScript() {
 ${virtualScriptContent}
 ${indent}}

--- a/src/index.js
+++ b/src/index.js
@@ -75,8 +75,8 @@ function iterateESLintModules(fn) {
 
 function addOnXXX(textOrSourceCode, config) {
   let indent = "    "
-  if(config && config.rules && config.rules.indent) {
-    if(config.rules.indent.includes("tab")) {
+  if (config && config.rules && config.rules.indent) {
+    if (config.rules.indent.includes("tab")) {
       indent = "\t"
     }
   }
@@ -86,7 +86,7 @@ function addOnXXX(textOrSourceCode, config) {
     {
       onopentag(name, attrs) {
         for (const id in attrs) {
-          if(regex.test(id)) {
+          if (regex.test(id)) {
             virtualScriptContent = virtualScriptContent.concat(`${indent}${indent}${attrs[id]}\n`)
           }
         }
@@ -94,9 +94,9 @@ function addOnXXX(textOrSourceCode, config) {
     }
   )
   parser.parseComplete(textOrSourceCode)
-  if(virtualScriptContent.length) {
+  if (virtualScriptContent.length) {
     let semi = ";"
-    if(config && config.rules && config.rules.semi && config.rules.semi.includes("never")) {
+    if (config && config.rules && config.rules.semi && config.rules.semi.includes("never")) {
       semi = ""
     }
     virtualScriptContent = virtualScriptContent.slice(0, -1)

--- a/src/index.js
+++ b/src/index.js
@@ -82,17 +82,15 @@ function addOnXXX(textOrSourceCode, config) {
   }
   let virtualScriptContent = ""
   const regex = /^on[a-zA-Z]+$/
-  const parser = new htmlparser.Parser(
-    {
-      onopentag(name, attrs) {
-        for (const id in attrs) {
-          if (regex.test(id)) {
-            virtualScriptContent = virtualScriptContent.concat(`${indent}${indent}${attrs[id]}\n`)
-          }
+  const parser = new htmlparser.Parser({
+    onopentag(name, attrs) {
+      for (const id in attrs) {
+        if (regex.test(id)) {
+          virtualScriptContent = virtualScriptContent.concat(`${indent}${indent}${attrs[id]}\n`)
         }
       }
     }
-  )
+  })
   parser.parseComplete(textOrSourceCode)
   if (virtualScriptContent.length) {
     let semi = ";"
@@ -106,7 +104,7 @@ ${virtualScriptContent}
 ${indent}}
 ${indent}virtualScript()${semi}
 </script>`
-    textOrSourceCode = textOrSourceCode.concat(virtualScript);
+    textOrSourceCode = textOrSourceCode.concat(virtualScript)
   }
   return textOrSourceCode
 }
@@ -119,7 +117,7 @@ function patch(Linter) {
     filenameOrOptions,
     saveState
   ) {
-    textOrSourceCode = addOnXXX(textOrSourceCode, config);
+    textOrSourceCode = addOnXXX(textOrSourceCode, config)
     const localVerify = code =>
       verify.call(this, code, config, filenameOrOptions, saveState)
 


### PR DESCRIPTION
This should fix https://github.com/BenoitZugmeyer/eslint-plugin-html/issues/61

Before linting, the file is parsed. If an attributes matching `/^on[a-zA-Z]+$/` is found, then its value is added to a virtual `<script>` element at the end of the file.

A problem remains : if there is an error in an attribute, the line number reported will not be accurate.