### PR TITLE
fix: prevent patching linter verify funtion multiple times

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ const getSettings = require("./settings").getSettings
 const BOM = "\uFEFF"
 const GET_SCOPE_RULE_NAME = "__eslint-plugin-html-get-scope"
 const DECLARE_VARIABLES_RULE_NAME = "__eslint-plugin-html-declare-variables"
+const LINTER_ISPATCHED_PROPERTY_NAME =
+  "__eslint-plugin-html-verify-function-is-patched"
 
 // Disclaimer:
 //
@@ -74,6 +76,12 @@ function iterateESLintModules(fn) {
 
 function patch(Linter) {
   const verify = Linter.prototype.verify
+
+  // ignore if verify function is already been patched sometime before
+  if (Linter[LINTER_ISPATCHED_PROPERTY_NAME] === true) {
+    return
+  }
+  Linter[LINTER_ISPATCHED_PROPERTY_NAME] = true
   Linter.prototype.verify = function(
     textOrSourceCode,
     config,


### PR DESCRIPTION
Hi. I was using atom as main editor to code file, using [linter-eslint](https://github.com/AtomLinter/linter-eslint/) to get eslint working in atom. 

I got a strange behavior while linting vue files, after digging in I find that the reason that this is happening is because linter-eslint import eslint to create eslint.CLIEngine from both project to lint files independently (but in one worker process)
https://github.com/AtomLinter/linter-eslint/blob/master/src/worker.js#L16
https://github.com/AtomLinter/linter-eslint/blob/master/src/worker-helpers.js#L111

while eslint-plugin-html patch the every linter it found when init itself, where we have 2 eslint imported, means that 2 eslint-plugin-html was imported too. This lead to some linter was patched more than 1 time, and it cause the fail linting. it could be easy reproduce by init 2 project with installed with eslint and eslint-plugin-html, and require both eslint in one node process, and try to lint vue files using those 2 eslint instances.

I think that tag the Linter as patched to prevent multiple patch should be good to fix this