### PR TITLE
Replace undocumented rules.define() with defineRule()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ function patch(Linter) {
     // Save code parts parsed source code so we don't have to parse it twice
     const sourceCodes = new WeakMap()
     const verifyCodePart = (codePart, { prepare, ignoreRules } = {}) => {
-      this.rules.define(PREPARE_RULE_NAME, context => {
+      this.defineRule(PREPARE_RULE_NAME, context => {
         sourceCodes.set(codePart, context.getSourceCode())
         return {
           Program() {


### PR DESCRIPTION
[Eslint `5.13.0` removed the undocumented `linter.rules` api](https://github.com/eslint/eslint/pull/11335), causing all my builds to fail. This PR replaces the undocumented API with the official one.