### PR TITLE
allow to pass an array of <script>-like tags to parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   - [`html/xml-extensions`](#htmlxml-extensions)
   - [`html/indent`](#htmlindent)
   - [`html/report-bad-indent`](#htmlreport-bad-indent)
-  - [`html/parse-tags`](#htmlparse-tags)
+  - [`html/javascript-tag-names`](#htmljavascript-tag-names)
   - [`html/javascript-mime-types`](#htmljavascript-mime-types)
 - [Troubleshooting](#troubleshooting)
   - [No file linted when running `eslint` on a directory](#no-file-linted-when-running-eslint-on-a-directory)
@@ -162,7 +162,7 @@ display errors. Example:
 }
 ```
 
-### `html/parse-tags`
+### `html/javascript-tag-names`
 
 By default, the code between `<script>` tags is considered as JavaScript. You can customize which
 tags should be considered JavaScript by providing one or multiple tag names.
@@ -173,7 +173,7 @@ Example:
 {
     "plugins": [ "html" ],
     "settings": {
-        "html/parse-tags": ["script", "customscript"],
+        "html/javascript-tag-names": ["script", "customscript"],
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -6,21 +6,25 @@
     <p>A <a href="http://eslint.org">ESLint</a> plugin to lint and fix inline scripts contained in HTML files.</p>
 </div>
 
-* [Usage](#usage)
-* [Multiple scripts tags in a HTML file](#multiple-scripts-tags-in-a-html-file)
-* [XML Support](#xml-support)
-* [Settings](#settings)
-  * [`html/html-extensions`](#htmlhtml-extensions)
-  * [`html/xml-extensions`](#htmlxml-extensions)
-  * [`html/indent`](#htmlindent)
-  * [`html/report-bad-indent`](#htmlreport-bad-indent)
-  * [`html/javascript-mime-types`](#htmljavascript-mime-types)
-* [Troubleshooting](#troubleshooting)
-  * [No file linted when running `eslint` on a directory](#no-file-linted-when-running-eslint-on-a-directory)
-  * [Linting templates (or PHP)](#linting-templates-or-php)
-  * [Linting Vue files](#linting-vue-files)
-* [Migration from older versions](#migration-from-older-versions)
-* [Credits](#credits)
+- [Usage](#usage)
+- [Multiple scripts tags in a HTML file](#multiple-scripts-tags-in-a-html-file)
+  - [History](#history)
+- [XML support](#xml-support)
+- [Settings](#settings)
+  - [`html/html-extensions`](#htmlhtml-extensions)
+  - [`html/xml-extensions`](#htmlxml-extensions)
+  - [`html/indent`](#htmlindent)
+  - [`html/report-bad-indent`](#htmlreport-bad-indent)
+  - [`html/parse-tags`](#htmlparse-tags)
+  - [`html/javascript-mime-types`](#htmljavascript-mime-types)
+- [Troubleshooting](#troubleshooting)
+  - [No file linted when running `eslint` on a directory](#no-file-linted-when-running-eslint-on-a-directory)
+  - [Linting templates (or PHP)](#linting-templates-or-php)
+  - [Linting VUE files](#linting-vue-files)
+- [Migration from older versions](#migration-from-older-versions)
+  - [To v4](#to-v4)
+  - [To v3](#to-v3)
+- [Credits](#credits)
 
 ## Usage
 
@@ -154,6 +158,21 @@ display errors. Example:
     "plugins": [ "html" ],
     "settings": {
         "html/report-bad-indent": "error",
+    }
+}
+```
+
+### `html/parse-tags`
+
+By default, the code between `<script>` tags is considered as JavaScript.
+
+Example:
+
+```javascript
+{
+    "plugins": [ "html" ],
+    "settings": {
+        "html/parse-tags": ["script", "customscript"],
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ display errors. Example:
 
 ### `html/parse-tags`
 
-By default, the code between `<script>` tags is considered as JavaScript.
+By default, the code between `<script>` tags is considered as JavaScript. You can customize which
+tags should be considered JavaScript by providing one or multiple tag names.
 
 Example:
 

--- a/src/__tests__/__snapshots__/extract.js.snap
+++ b/src/__tests__/__snapshots__/extract.js.snap
@@ -46,6 +46,15 @@ Array [
 ]
 `;
 
+exports[`extract multiple tags types 1`] = `
+Array [
+  "var foo = 1;
+",
+  "var bar = 1;
+",
+]
+`;
+
 exports[`extract script containing 'lower than' characters correctly (#1) 1`] = `
 Array [
   "if (a < b) { doit(); }

--- a/src/__tests__/extract.js
+++ b/src/__tests__/extract.js
@@ -25,7 +25,7 @@ function test(params) {
     dedent(params.input),
     params.indent,
     params.xmlMode,
-    params.parseTags || ["script"],
+    params.javaScriptTagNames || ["script"],
     params.isJavaScriptMIMEType
   )
   expect(infos.code.map((code) => code.toString())).toMatchSnapshot()
@@ -331,6 +331,6 @@ it("extract multiple tags types", () => {
         var bar = 1;
       </customscript>
     `,
-    parseTags: ["script", "customscript"],
+    javaScriptTagNames: ["script", "customscript"],
   })
 })

--- a/src/__tests__/extract.js
+++ b/src/__tests__/extract.js
@@ -25,6 +25,7 @@ function test(params) {
     dedent(params.input),
     params.indent,
     params.xmlMode,
+    params.parseTags || ["script"],
     params.isJavaScriptMIMEType
   )
   expect(infos.code.map((code) => code.toString())).toMatchSnapshot()
@@ -315,5 +316,21 @@ it("handles self closing script tags in xhtml mode", () => {
 it("skips script with src attributes", () => {
   test({
     input: '<script src="foo"></script>',
+  })
+})
+
+it("extract multiple tags types", () => {
+  test({
+    input: `
+      some html
+      <script>
+        var foo = 1;
+      </script>
+      other
+      <customscript>
+        var bar = 1;
+      </customscript>
+    `,
+    parseTags: ["script", "customscript"],
   })
 })

--- a/src/extract.js
+++ b/src/extract.js
@@ -8,7 +8,7 @@ function iterateScripts(code, options, onChunk) {
 
   const xmlMode = options.xmlMode
   const isJavaScriptMIMEType = options.isJavaScriptMIMEType || (() => true)
-  const parseTags = options.parseTags || ['script']
+  const javaScriptTagNames = options.javaScriptTagNames || ['script']
   let index = 0
   let inScript = false
   let cdata = []
@@ -24,7 +24,7 @@ function iterateScripts(code, options, onChunk) {
     {
       onopentag(name, attrs) {
         // Test if current tag is a valid <script> tag.
-        if (!parseTags.includes(name)) {
+        if (!javaScriptTagNames.includes(name)) {
           return
         }
 
@@ -54,7 +54,7 @@ function iterateScripts(code, options, onChunk) {
       },
 
       onclosetag(name) {
-        if (!parseTags.includes(name) || !inScript) {
+        if (!javaScriptTagNames.includes(name) || !inScript) {
           return
         }
 
@@ -180,13 +180,13 @@ function* dedent(indent, slice) {
   }
 }
 
-function extract(code, indentDescriptor, xmlMode, parseTags, isJavaScriptMIMEType) {
+function extract(code, indentDescriptor, xmlMode, javaScriptTagNames, isJavaScriptMIMEType) {
   const badIndentationLines = []
   const codeParts = []
   let lineNumber = 1
   let previousHTML = ""
 
-  iterateScripts(code, { xmlMode, parseTags, isJavaScriptMIMEType }, (chunk) => {
+  iterateScripts(code, { xmlMode, javaScriptTagNames, isJavaScriptMIMEType }, (chunk) => {
     const slice = code.slice(chunk.start, chunk.end)
     if (chunk.type === "html") {
       const match = slice.match(/\r\n|\n|\r/g)

--- a/src/extract.js
+++ b/src/extract.js
@@ -8,6 +8,7 @@ function iterateScripts(code, options, onChunk) {
 
   const xmlMode = options.xmlMode
   const isJavaScriptMIMEType = options.isJavaScriptMIMEType || (() => true)
+  const parseTags = options.parseTags || ['script']
   let index = 0
   let inScript = false
   let cdata = []
@@ -23,7 +24,7 @@ function iterateScripts(code, options, onChunk) {
     {
       onopentag(name, attrs) {
         // Test if current tag is a valid <script> tag.
-        if (name !== "script") {
+        if (!parseTags.includes(name)) {
           return
         }
 
@@ -53,7 +54,7 @@ function iterateScripts(code, options, onChunk) {
       },
 
       onclosetag(name) {
-        if (name !== "script" || !inScript) {
+        if (!parseTags.includes(name) || !inScript) {
           return
         }
 
@@ -179,13 +180,13 @@ function* dedent(indent, slice) {
   }
 }
 
-function extract(code, indentDescriptor, xmlMode, isJavaScriptMIMEType) {
+function extract(code, indentDescriptor, xmlMode, parseTags, isJavaScriptMIMEType) {
   const badIndentationLines = []
   const codeParts = []
   let lineNumber = 1
   let previousHTML = ""
 
-  iterateScripts(code, { xmlMode, isJavaScriptMIMEType }, (chunk) => {
+  iterateScripts(code, { xmlMode, parseTags, isJavaScriptMIMEType }, (chunk) => {
     const slice = code.slice(chunk.start, chunk.end)
     if (chunk.type === "html") {
       const match = slice.match(/\r\n|\n|\r/g)

--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,7 @@ function patch(Linter) {
       textOrSourceCode,
       pluginSettings.indent,
       mode === "xml",
+      pluginSettings.parseTags,
       pluginSettings.isJavaScriptMIMEType
     )
 

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ function patch(Linter) {
       textOrSourceCode,
       pluginSettings.indent,
       mode === "xml",
-      pluginSettings.parseTags,
+      pluginSettings.javaScriptTagNames,
       pluginSettings.isJavaScriptMIMEType
     )
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -49,6 +49,9 @@ function getSettings(settings) {
     getSetting(settings, "xml-extensions") ||
     filterOut(defaultXMLExtensions, getSetting(settings, "html-extensions"))
 
+  const parseTags =
+    getSetting(settings, "parse-tags") || ["script"]
+
   let reportBadIndent
   switch (getSetting(settings, "report-bad-indent")) {
     case undefined:
@@ -101,6 +104,7 @@ function getSettings(settings) {
   return {
     htmlExtensions,
     xmlExtensions,
+    parseTags,
     indent,
     reportBadIndent,
     isJavaScriptMIMEType,

--- a/src/settings.js
+++ b/src/settings.js
@@ -50,8 +50,9 @@ function getSettings(settings) {
     getSetting(settings, "xml-extensions") ||
     filterOut(defaultXMLExtensions, getSetting(settings, "html-extensions"))
 
-  const parseTags =
-    getSetting(settings, "parse-tags") || ["script"]
+  const javaScriptTagNames = getSetting(settings, "javascript-tag-names") || [
+    "script",
+  ]
 
   let reportBadIndent
   switch (getSetting(settings, "report-bad-indent")) {
@@ -105,7 +106,7 @@ function getSettings(settings) {
   return {
     htmlExtensions,
     xmlExtensions,
-    parseTags,
+    javaScriptTagNames,
     indent,
     reportBadIndent,
     isJavaScriptMIMEType,


### PR DESCRIPTION
Add a setting for linting other types of tags as `<script>` tags. This was needed for certain platforms that use javascript syntax within their own tag structure.