### PR TITLE
Add .riot extension

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -12,6 +12,7 @@ const defaultHTMLExtensions = [
   ".nunjucks",
   ".php",
   ".tag",
+  ".riot",
   ".twig",
   ".we",
 ]


### PR DESCRIPTION
`.riot` is an [official Github extension](https://github.com/github/linguist/pull/4653) and it might be worth to support it. `.tag` is no longer used for Riot.js components, it can be left here in the list for backward compatibility