### PR TITLE
chore: Add Dependabot for updates 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 99
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 99

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
   schedule:
     # Every sunday at midnight
     - cron:  '0 0 * * 0'


### PR DESCRIPTION
Dependabot will open PRs for NPM and GitHub Action dependencies.
Filter on CI so there isn't double runs when it creates the PR branches