### PR TITLE
chore: Update setup-node and use caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,9 +41,10 @@ jobs:
             eslint: next
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - run: npm ci
       - run: npm install eslint@${{ matrix.eslint }}
       - run: npm test


### PR DESCRIPTION
New version supports caching based on package-lock.json file