### PR TITLE
fix: don't crash when ESLint is not loaded

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -15,7 +15,7 @@ Describe the issue precisely: what are you trying to do? what's the expected res
 - eslint-plugin-html version:
 - NodeJS version:
 - Operating System name and version:
-- ESLint configuration (.eslintrc):
+- ESLint configuration (.eslintrc/eslint.config.js):
 
 <!--
 If run from an editor plugin:

--- a/src/index.js
+++ b/src/index.js
@@ -72,40 +72,8 @@ function iterateESLintModules(fn) {
   }
 
   if (!found) {
-    let eslintPath, eslintVersion
-    try {
-      eslintPath = require.resolve("eslint")
-    } catch {
-      eslintPath = "(not found)"
-    }
-    try {
-      eslintVersion = require("eslint/package.json").version
-    } catch {
-      eslintVersion = "n/a"
-    }
-
-    const parentPaths = (module) =>
-      module ? [module.filename].concat(parentPaths(module.parent)) : []
-
-    throw new Error(
-      `eslint-plugin-html error: It seems that eslint is not loaded.
-If you think this is a bug, please file a report at https://github.com/BenoitZugmeyer/eslint-plugin-html/issues
-
-In the report, please include *all* those informations:
-
-* ESLint version: ${eslintVersion}
-* ESLint path: ${eslintPath}
-* Plugin version: ${require("../package.json").version}
-* Plugin inclusion paths: ${parentPaths(module).join(", ")}
-* NodeJS version: ${process.version}
-* CLI arguments: ${JSON.stringify(process.argv)}
-* Content of your lock file (package-lock.json or yarn.lock) or the output of \`npm list\`
-* How did you run ESLint (via the command line? an editor plugin?)
-* The following stack trace:
-    ${new Error().stack.slice(10)}
-
-
-      `
+    console.warn(
+      `⚠ eslint-plugin-html warning: ESLint is not loaded, HTML files will fail to lint. If you don't intend to lint HTML files, you can safely ignore this warning. If you think this is a bug, please file a report at https://github.com/BenoitZugmeyer/eslint-plugin-html/issues`
     )
   }
 }


### PR DESCRIPTION
Before ESLint 9, the plugin needed to be imported only when actually linting files. Tools inspecting the configuration didn't need to import the plugin, as the configuration was declared as a plain JSON.

With ESLint 9, tools inspecting the configuration actually need to evaluate the configuration file wich imports the plugin. So it has a higher chance to be evaluated outside of ESLint.

To allow such use case, don't throw an exception when the plugin is not loaded through ESLint, but rather display a warning. The bug report template should be enough to gather the needed information.

Fixes https://github.com/BenoitZugmeyer/eslint-plugin-html/issues/264