### PR TITLE
harden: sanitize child_process call in release.js...

### DIFF
--- a/tools/release.js
+++ b/tools/release.js
@@ -1,5 +1,5 @@
 "use strict"
-const { execSync: exec } = require("child_process")
+const { execSync: exec, execFileSync } = require("child_process")
 const { readFileSync: read } = require("fs")
 const { request } = require("https")
 const { version: currentVersion } = require("../package.json")
@@ -125,7 +125,7 @@ function createVersion(version) {
 
   console.log(`Creating version ${version}`)
 
-  exec(`npm version ${version}`, {
+  execFileSync("npm", ["version", version], {
     stdio: "inherit",
   })
 
@@ -192,7 +192,7 @@ function fetchWorkflowRuns() {
 function releaseVersion(version, channel) {
   console.log(`Publishing ${version} to channel ${channel}`)
 
-  exec(`npm publish --tag ${channel}`, {
+  execFileSync("npm", ["publish", "--tag", channel], {
     stdio: "inherit",
   })
   exec("git push --tags", {


### PR DESCRIPTION
## Summary
Harden input handling in `tools/release.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `tools/release.js:128` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `version`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `tools/release.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
